### PR TITLE
New Section Supported models

### DIFF
--- a/get-started/supported-models.mdx
+++ b/get-started/supported-models.mdx
@@ -1,0 +1,72 @@
+---
+icon: wrench
+---
+You will find all the list of supported large langugage models and embedding models along with their tier here. Learn moe about tiers in our [credits](https://docs.premai.io/get-started/credits) page. 
+
+<div style={{ display: 'flex', justifyContent: 'space-between' }}>
+
+<div style={{ width: '48%' }}>
+### Supported LLMs
+
+| **Model**                  | **Tier** |
+|----------------------------|----------|
+| claude-3-opus              | high     |
+| gpt-4-eu                   | high     |
+| claude-3-sonnet            | medium   |
+| mistral-large              | medium   |
+| command-r-plus             | medium   |
+| gpt-4-turbo                | medium   |
+| gpt-4o                     | medium   |
+| gemini-pro                 | medium   |
+| claude-3-haiku             | low      |
+| codellama-70b-instruct     | low      |
+| mixtral-8x7b-instruct-v0.1 | low      |
+| mistral-7b-instruct-v0.1   | low      |
+| gemma-7b-it                | low      |
+| gpt-3.5-turbo-eu           | low      |
+| command-r                  | low      |
+| llama-3-8b-fast            | low      |
+| llama-3-70b-fast           | low      |
+| mixtral-8x7b-fast          | low      |
+| gemma-7b-it-fast           | low      |
+| mistral-small              | low      |
+| gpt-3.5-turbo              | low      |
+| stripedhyena-nous-7b       | low      |
+| mythalion-13b              | low      |
+| llama-3-70b-instruct       | low      |
+| llama-3-8b-instruct        | low      |
+| mythomax-l2-13b            | low      |
+| remm-slerp-l2-13b          | low      |
+| yi-34-chat                 | low      |
+| zephyr-7b-beta             | low      |
+| chronos-hermes-13b         | low      |
+| mixtral-8x22b              | low      |
+| dolphin-mixtral-8x7b       | low      |
+| rwkv-5-world-3b            | low      |
+
+</div>
+
+<div style={{ width: '48%' }}>
+
+### Supported Embedding Models 
+
+| **Model**                  | **Tier** |
+|----------------------------|----------|
+| embed-multilingual         | low      |
+| embed-multilingual-light   | low      |
+| embed-english              | low      |
+| all-mpnet-base-v2          | low      |
+| embed-english-light        | low      |
+| gte-large                  | low      |
+| bge-large-en-v1.5          | low      |
+| text-embedding-3-large     | low      |
+| text-embedding-ada-002     | low      |
+| bge-base-en                | low      |
+| bge-large-en               | low      |
+| bge-small-en               | low      |
+| text-embedding-3-small     | low      |
+| mistral-embed              | low      |
+
+</div>
+
+</div>

--- a/integrations/langchain.mdx
+++ b/integrations/langchain.mdx
@@ -138,20 +138,13 @@ model = "text-embedding-3-large"
 embedder = PremEmbeddings(project_id=8, model=model)
 ```
 ### Setup PremAIEmbeddings instance in LangChain
-We have defined our embedding model. We support a lot of embedding models. Here is a table that shows the number of embedding models we support. 
 
+We have defined our embedding model. We support a lot of embedding models. 
+You can find all the list of supported embedding models [here](https://docs.premai.io/get-started/supported-models). 
 
-| Provider    | Slug                                     | Context Tokens |
-|-------------|------------------------------------------|----------------|
-| cohere      | embed-english-v3.0                       | N/A            |
-| openai      | text-embedding-3-small                   | 8191           |
-| openai      | text-embedding-3-large                   | 8191           |
-| openai      | text-embedding-ada-002                   | 8191           |
-| replicate   | replicate/all-mpnet-base-v2              | N/A            |
-| together    | togethercomputer/Llama-2-7B-32K-Instruct | N/A            |
-| mistralai   | mistral-embed                            | 4096           |
+To change the model, you simply need to copy the name from `Model` column and you will have the access your embedding model. 
 
-To change the model, you simply need to copy the `slug` and access your embedding model. Now let's start using our embedding model with a single query followed by multiple queries (which is also called as a document)
+Now let's start using our embedding model with a single query followed by multiple queries (which is also called as a document)
 
 ```python
 query = "Hello, this is a test query"

--- a/integrations/llamaindex.mdx
+++ b/integrations/llamaindex.mdx
@@ -124,21 +124,12 @@ from llama_index.embeddings.premai import PremAIEmbeddings
 ```
 ## Setup PremAIEmbeddings instance in LlamaIndex
 
-Once we imported our required modules, let's setup our client. For now let's assume that our `project_id` is `8`. But make sure you use your project-id, otherwise it will throw error. In case of embeddings you also have to additionally pass `model`. 
+We have defined our embedding model. We support a lot of embedding models. 
+You can find all the list of supported embedding models [here](https://docs.premai.io/get-started/supported-models). 
 
-Here are the list of available models on PremAI:
+To change the model, you simply need to copy the name from `Model` column and you will have the access your embedding model. 
 
-| Provider    | Slug                                     | Context Tokens |
-|-------------|------------------------------------------|----------------|
-| cohere      | embed-english-v3.0                       | N/A            |
-| openai      | text-embedding-3-small                   | 8191           |
-| openai      | text-embedding-3-large                   | 8191           |
-| openai      | text-embedding-ada-002                   | 8191           |
-| replicate   | replicate/all-mpnet-base-v2              | N/A            |
-| together    | togethercomputer/Llama-2-7B-32K-Instruct | N/A            |
-| mistralai   | mistral-embed                            | 4096           |
-
-To change the model, you simply need to copy the `slug` and access your embedding model.
+Now let's start using our embedding model with a single query followed by multiple queries (which is also called as a document)
 
 ```python
 import os

--- a/mint.json
+++ b/mint.json
@@ -65,6 +65,7 @@
         "get-started/gym",
         "get-started/sdk",
         "get-started/chat-completion-sse",
+        "get-started/supported-models",
         "get-started/credits"
       ]
     },

--- a/mint.json.template
+++ b/mint.json.template
@@ -66,6 +66,7 @@
         "get-started/gym",
         "get-started/sdk",
         "get-started/chat-completion-sse",
+        "get-started/supported-models", 
         "get-started/credits"
       ]
     },


### PR DESCRIPTION
This PR adds the following:

1. List of supported LLMs/embedding models with tier information 
2. Updated langchain and llama-index saas native documentation page redirect to supported models. 

Here is how the page looks like: 

![Screenshot 2024-05-21 at 10 58 03 PM](https://github.com/premAI-io/prem-saas-docs/assets/58508471/f479324f-905a-447c-8292-5b77257436b6)
