### PR TITLE
Improve JSON Output Guide

### DIFF
--- a/guides/inference/json-output.mdx
+++ b/guides/inference/json-output.mdx
@@ -37,7 +37,7 @@ Perfect for dev teams building HR tools, job platforms, or internal automation s
             export PREMAI_API_KEY=your_api_key
             ```
             ```bash python
-            pip install premai pydantic
+            pip install premai pydantic json-repair
             export PREMAI_API_KEY=your_api_key
             ```
         </CodeGroup>
@@ -99,6 +99,7 @@ Perfect for dev teams building HR tools, job platforms, or internal automation s
             ```
             ```python python
             from pydantic import BaseModel
+            import json_repair
 
 
             class PersonCV(BaseModel):
@@ -148,6 +149,7 @@ Perfect for dev teams building HR tools, job platforms, or internal automation s
             ```python python
             import os
             from premai import PremAI
+            import json_repair
 
             client = PremAI(api_key=os.getenv("PREMAI_API_KEY"))
             ```
@@ -207,22 +209,16 @@ Perfect for dev teams building HR tools, job platforms, or internal automation s
             console.log(JSON.stringify(parsed, null, 2));
             ```
             ```python python
-            import json
-
             content = response.choices[0].message.content
 
-            start = content.find("{")
-            end = content.rfind("}") + 1
-            json_content = content[start:end]
-
-            output = json.loads(json_content)
+            output = json_repair.loads(content)
             parsed = PersonCV.model_validate(output)
 
-            print(json.dumps(parsed.model_dump(), indent=2))
+            print(parsed.model_dump_json(indent=2))
             ```
         </CodeGroup>
         <Note>
-        In the code above, the lines using `find("{")` and `rfind("}")` are a simple safeguard to extract only the JSON portion from the model's output. Sometimes, the response may include extra text before or after the JSON block. This ensures that only the valid JSON is parsed, avoiding potential `json.loads()` errors.
+        The `json_repair.loads()` function automatically handles malformed JSON and extracts valid JSON from text that may contain extra content before or after the JSON block. This is much more robust than using `json.loads()` and manual string extraction, which can fail with malformed JSON responses.
         </Note>
     </Step>
 
@@ -322,7 +318,7 @@ console.log(JSON.stringify(parsed, null, 2));
 import os
 from pydantic import BaseModel
 from premai import PremAI
-import json
+import json_repair
 
 
 class PersonCV(BaseModel):
@@ -378,14 +374,10 @@ response = client.chat.completions(
 
 content = response.choices[0].message.content
 
-start = content.find("{")
-end = content.rfind("}") + 1
-json_content = content[start:end]
-
-output = json.loads(json_content)
+output = json_repair.loads(content)
 parsed = PersonCV.model_validate(output)
 
-print(json.dumps(parsed.model_dump(), indent=2))
+print(parsed.model_dump_json(indent=2))
 ```
 </CodeGroup>
 
@@ -393,7 +385,8 @@ print(json.dumps(parsed.model_dump(), indent=2))
 
 ## Pro Tips
 
-- If you run into JSON parsing errors, try using the [instructor](https://python.useinstructor.com/) and [json-repair](https://github.com/mangiucugna/json_repair) package — they can help you automatically fix malformed model outputs.
+- We use the [json-repair](https://github.com/mangiucugna/json_repair) package to automatically handle malformed JSON and extract valid JSON from model responses, making the parsing much more robust than using `json.loads()`.
+- For even more advanced structured output handling, consider using the [instructor](https://python.useinstructor.com/) package which provides additional validation and retry mechanisms.
 - If the model doesn't follow your schema correctly, simplify the schema by reducing nesting or optional fields.
 - Be explicit in your instructions (e.g., "Return only valid JSON without any explanation or extra text.")
 - Include examples in your prompt (few-shot prompting) to help the model understand the expected format more accurately.


### PR DESCRIPTION
- replace list of supported models with https://studio.premai.io/models : this removes the need to constantly change the list anytime a new model is added or removed (e.g.: gpt-4 / gpt-5)
- replace json.loads with json_repair 


N.B.: the JSON tag inside the models' page at https://studio.premai.io/models has been added in this pending [PR](https://github.com/premAI-io/sid/pull/617)